### PR TITLE
fix: 修复了发表带话题笔记，右侧话题榜单不更新的问题

### DIFF
--- a/page-notes.php
+++ b/page-notes.php
@@ -83,7 +83,7 @@ get_header(); ?>
                         <aside class="notes-aside">
                             <section class="sticky">
                                 <heat-map />
-                                <topic-list :active="search.topics" @topic="handleTopic" />
+                                <topic-list ref="topicList" :active="search.topics" @topic="handleTopic" />
                             </section>
                         </aside>
                     </div>
@@ -228,6 +228,9 @@ get_header(); ?>
                         this.$refs.editor.setLoading(true);
                         $modules.actions.setNotes(this.form, { content, files }).then(() => {
                             this.$refs.editor.clear();
+                            if(content.match(/.?#([^#|^<\s]+)/g)) {
+                                this.$refs.topicList.getTopics();
+                            }
                             this.reset();
                             this.search.type = this.private ? 'private' : 'note';
                             if ( ['all', 'note'].includes(this.search.type) || (this.private && this.search.type === 'private') ) {


### PR DESCRIPTION
问题描述：

现在发布带话题，右侧话题榜单不会立即更新，下次刷新才会更新

解决方案：

在发布笔记成功以后，返回的`content`通过正则判断，如果带有话题，通过`ref`手动触发一下`topic-list`子组件的更新方法`getTopics`
