### PR TITLE
Use wp_parse_url() instead of parse_url()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -43,7 +43,7 @@ function biji_enqueue_scripts() {
     wp_enqueue_script( 'language', get_template_directory_uri() . '/static/lang.js', [], THEME_VERSION, false );
     wp_enqueue_script( 'modules', get_template_directory_uri() . '/static/modules.js', [], THEME_VERSION, true );
     wp_enqueue_script( 'script', get_template_directory_uri() . '/static/script.js', [], THEME_VERSION, true );
-    $avatar_url = parse_url( get_avatar_url( null ) );
+    $avatar_url = wp_parse_url( get_avatar_url( null ) );
     wp_localize_script( 'helper', 'BaseData', [
         'origin' => site_url(),
         'avatar' => "//" . $avatar_url["host"],

--- a/inc/core.php
+++ b/inc/core.php
@@ -46,7 +46,7 @@ add_filter( 'preprocess_comment', 'scp_comment_post' );
 // Gravatar头像使用镜像服务器
 function biji_replace_avatar( $avatar ) {
     if ( get_theme_mod( 'biji_setting_avatar' ) ) {
-        $cdn    = parse_url( get_theme_mod( 'biji_setting_avatar' ) );
+        $cdn    = wp_parse_url( get_theme_mod( 'biji_setting_avatar' ) );
         $host   = $cdn["host"];
         $avatar = preg_replace( "/\/\/(.*?).gravatar.com/", "//$host", $avatar );
     }


### PR DESCRIPTION
Two small standards swaps. `functions.php` (the avatar host lookup) and `inc/core.php` (the CDN avatar rewrite) both use `parse_url()`, which is on the WordPress coding-standards discouraged list. `wp_parse_url()` is the drop-in wrapper that also handles scheme-relative URLs.

`wp_parse_url()` returns the same array as `parse_url()` for an absolute URL and is only more correct for a scheme-relative one, so the following `["host"]` reads behave exactly as before.

Wing's tidy enough that the two call sites were quick to find.

(full disclosure: AI helped me find these; the change and this note are mine.)
